### PR TITLE
修复退出登录闪退问题

### DIFF
--- a/lib/http/request_repository.dart
+++ b/lib/http/request_repository.dart
@@ -239,7 +239,7 @@ class RequestRepository {
     Success<bool>? success,
     Fail? fail,
   }) {
-    Request.post<dynamic>(RequestApi.apiLogout, {}, dialog: false,
+    Request.get<dynamic>(RequestApi.apiLogout, {}, dialog: false,
         success: (data) {
       if (success != null) {
         success(true);


### PR DESCRIPTION
退出登录时会闪退，因为退出登录是 get 请求，代码中写成 post